### PR TITLE
Add canvas management APIs and UI

### DIFF
--- a/canvas/_base_canvas.py
+++ b/canvas/_base_canvas.py
@@ -1,13 +1,13 @@
 import uuid
 import importlib
-import pkgutil
 import inspect
-from typing import Callable, Tuple
+import pkgutil
+from typing import Callable
 
 
 from PIL import Image, ImageDraw, ImageFont
 
-import views
+from . import views
 
 
 
@@ -30,7 +30,8 @@ class _BaseCanvas():
                 if view_cls:
                     view_cls.draw(draw, view_config)
             except Exception as e:
-                print(f"Error rendering view {view_config["type"]}: {e}")
+                view_type = view_config.get("type") if isinstance(view_config, dict) else "unknown"
+                print(f"Error rendering view {view_type}: {e}")
         return canvas_img
 
     @staticmethod

--- a/canvas/_canvas_template.py
+++ b/canvas/_canvas_template.py
@@ -2,10 +2,10 @@ import sys
 from pathlib import Path
 
 try:
-    # preferred when run as a package: python -m canvas.canvas1
+    # preferred when run as a package: python -m canvas.new_canvas
     from ._base_canvas import _BaseCanvas
 except Exception:
-    # fallback when running the file directly: python canvas/canvas1.py
+    # fallback when running the file directly: python canvas/new_canvas.py
     # add project root to sys.path and import absolute package
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
     from canvas._base_canvas import _BaseCanvas
@@ -13,18 +13,33 @@ except Exception:
 from PIL import Image, ImageDraw, ImageFont
 
 
-
-
 class Canvas(_BaseCanvas):
 
-    ID = ""
+    ID = "new_canvas"
 
     @classmethod
     def render(cls) -> Image.Image:
         return cls._render(CONFIG)
 
+    # Add view builder functions here. For example:
+    # @staticmethod
+    # def example_view() -> dict:
+    #     return {
+    #         "type": "SquareView",
+    #         "location_x": 16,
+    #         "location_y": 16,
+    #         "width": 100,
+    #         "height": 100,
+    #     }
+
 
 CONFIG = {
-        "name": "MyCanvas",
-        "views": {}  # view_id -> view_builder
-    }
+    "name": "New Canvas",
+    "views": {
+        # "example_view": Canvas.example_view,
+    }  # view_id -> view_builder
+}
+
+if __name__ == "__main__":
+    img = Canvas.render()
+    img.show()

--- a/canvas/canvas1.py
+++ b/canvas/canvas1.py
@@ -13,35 +13,60 @@ except Exception:
 from PIL import Image, ImageDraw, ImageFont
 
 
-
-
 class Canvas(_BaseCanvas):
 
-    ID = "Canvas1"
+    ID = "canvas1"
 
     @classmethod
     def render(cls) -> Image.Image:
         return cls._render(CONFIG)
 
     @staticmethod
-    def v1() -> None:
-        config = {
-            "type": "_NewViewTemplate",
-            "location_x": 0,
-            "location_y": 0,
-            "width": 296,
-            "height": 152,
-            "custom_param": "Example Parameter Value"
+    def hero_square() -> dict:
+        return {
+            "type": "SquareView",
+            "location_x": 16,
+            "location_y": 16,
+            "width": 120,
+            "height": 120,
+            "fill": "#BFDBFE",
+            "outline": "#1D4ED8",
         }
-        return config
+
+    @staticmethod
+    def spotlight_circle() -> dict:
+        return {
+            "type": "CircleView",
+            "location_x": 156,
+            "location_y": 24,
+            "width": 96,
+            "height": 96,
+            "fill": "#FDE68A",
+            "outline": "#92400E",
+        }
+
+    @staticmethod
+    def headline_text() -> dict:
+        return {
+            "type": "TextView",
+            "location_x": 24,
+            "location_y": 40,
+            "width": 200,
+            "height": 40,
+            "text": "Canvas 1",
+            "fill": "#111827",
+            "font_size": 24,
+        }
 
 
 CONFIG = {
-        "name": "Canvas1",
-        "views": {
-            "v1": Canvas.v1
-        }  # view_id -> view_builder
-    }
+    "name": "Canvas 1",
+    "views": {
+        "hero_square": Canvas.hero_square,
+        "spotlight_circle": Canvas.spotlight_circle,
+        "headline_text": Canvas.headline_text,
+    }  # view_id -> view_builder
+}
 
 if __name__ == "__main__":
     img = Canvas.render()

--- a/canvas/canvas_manager/__init__.py
+++ b/canvas/canvas_manager/__init__.py
@@ -1,0 +1,299 @@
+"""Utilities for creating, reading, and updating canvas modules."""
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, List
+
+from .._base_canvas import _BaseCanvas
+
+
+CANVAS_DIR = Path(__file__).resolve().parents[1]
+CANVAS_TEMPLATE = CANVAS_DIR / "_canvas_template.py"
+
+
+class CanvasManagerError(RuntimeError):
+    """Base error for canvas manager operations."""
+
+
+class CanvasNotFoundError(CanvasManagerError):
+    """Raised when a requested canvas file cannot be located."""
+
+
+@dataclass
+class ViewDefinition:
+    """Represents the editable portion of a view builder."""
+
+    view_id: str
+    code: str  # Body of the staticmethod (indented with 8 spaces when written)
+
+
+@dataclass
+class CanvasDefinition:
+    """Serializable representation of a canvas module."""
+
+    canvas_id: str
+    name: str
+    views: List[ViewDefinition]
+
+
+def _canvas_file(canvas_id: str) -> Path:
+    """Return the path to the canvas module for ``canvas_id``."""
+
+    path = CANVAS_DIR / f"{canvas_id}.py"
+    if not path.exists():
+        raise CanvasNotFoundError(f"Canvas '{canvas_id}' does not exist")
+    return path
+
+
+def list_canvases() -> List[Dict[str, str]]:
+    """Return a summary of all available canvases."""
+
+    canvases: List[Dict[str, str]] = []
+    for file in sorted(CANVAS_DIR.glob("*.py")):
+        if file.name.startswith("_") or file.name == "__init__.py":
+            continue
+        try:
+            definition = load_canvas(file.stem)
+        except CanvasManagerError:
+            continue
+        canvases.append({
+            "id": definition.canvas_id,
+            "name": definition.name,
+        })
+    return canvases
+
+
+def load_canvas(canvas_id: str) -> CanvasDefinition:
+    """Parse a canvas file and return its editable representation."""
+
+    path = _canvas_file(canvas_id)
+    source = path.read_text()
+    module_ast = ast.parse(source)
+
+    canvas_class = _find_canvas_class(module_ast)
+    class_id = _extract_class_id(canvas_class)
+
+    config_assign = _find_config_assignment(module_ast)
+    name, ordered_view_ids = _extract_config_metadata(config_assign)
+
+    view_code_map = _extract_view_bodies(canvas_class, source.splitlines())
+
+    views: List[ViewDefinition] = []
+    seen: set[str] = set()
+    for view_id in ordered_view_ids:
+        code = view_code_map.get(view_id, "return {}\n")
+        views.append(ViewDefinition(view_id=view_id, code=code))
+        seen.add(view_id)
+
+    for extra_id, code in view_code_map.items():
+        if extra_id not in seen:
+            views.append(ViewDefinition(view_id=extra_id, code=code))
+
+    return CanvasDefinition(canvas_id=class_id, name=name, views=views)
+
+
+def create_canvas(canvas_id: str, name: str) -> CanvasDefinition:
+    """Create a new canvas module from the template."""
+
+    destination = CANVAS_DIR / f"{canvas_id}.py"
+    if destination.exists():
+        raise CanvasManagerError(f"Canvas '{canvas_id}' already exists")
+
+    template_source = CANVAS_TEMPLATE.read_text()
+    base_definition = CanvasDefinition(canvas_id=canvas_id, name=name, views=[])
+    rendered = _render_canvas_source(base_definition, template_source)
+    destination.write_text(rendered)
+    importlib.invalidate_caches()
+    return base_definition
+
+
+def save_canvas(canvas_id: str, name: str, views: List[Dict[str, Any]]) -> CanvasDefinition:
+    """Persist updates to a canvas module."""
+
+    existing = load_canvas(canvas_id)
+    existing.name = name
+    existing.views = [ViewDefinition(view_id=v["id"], code=v["code"]) for v in views]
+
+    template_source = CANVAS_TEMPLATE.read_text()
+    rendered = _render_canvas_source(existing, template_source)
+    path = _canvas_file(canvas_id)
+    path.write_text(rendered)
+    importlib.invalidate_caches()
+    return existing
+
+
+def render_canvas(canvas_id: str) -> "Image.Image":
+    """Render a canvas image using its Canvas class."""
+
+    importlib.invalidate_caches()
+    module = _load_canvas_module(canvas_id)
+    canvas_cls = getattr(module, "Canvas")
+    return canvas_cls.render()
+
+
+def load_view_configs(canvas_id: str) -> List[Dict[str, Any]]:
+    """Evaluate the view builder functions and return their configs."""
+
+    module = _load_canvas_module(canvas_id)
+
+    configs: List[Dict[str, Any]] = []
+    for view_id, builder in module.CONFIG.get("views", {}).items():
+        try:
+            configs.append({
+                "id": view_id,
+                "config": builder(),
+                "error": None,
+            })
+        except Exception as exc:  # pragma: no cover - runtime feedback for UI
+            configs.append({
+                "id": view_id,
+                "config": None,
+                "error": str(exc),
+            })
+    return configs
+
+
+def list_available_views() -> List[Dict[str, Any]]:
+    """Return the available view classes discovered by :class:`_BaseCanvas`."""
+
+    views = []
+    for view_type, cls in _BaseCanvas.find_available_views().items():
+        views.append({
+            "type": view_type,
+            "params": cls.PARAMS,
+        })
+    return views
+
+
+def _load_canvas_module(canvas_id: str) -> ModuleType:
+    module_name = f"canvas.{canvas_id}"
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        raise CanvasNotFoundError(f"Canvas '{canvas_id}' cannot be imported") from exc
+    return importlib.reload(module)
+
+
+def _render_canvas_source(definition: CanvasDefinition, template_source: str) -> str:
+    """Render a canvas module using the template as a baseline."""
+
+    class_marker = "class Canvas(_BaseCanvas):"
+    preamble, marker, _ = template_source.partition(class_marker)
+    if not marker:
+        raise CanvasManagerError("Invalid canvas template: missing Canvas class definition")
+
+    preamble = preamble.replace("new_canvas", definition.canvas_id)
+    preamble = preamble.rstrip() + "\n\n"
+    header = f"{preamble}{marker}\n\n"
+
+    name_literal = json.dumps(definition.name)
+
+    view_sections = []
+    for view in definition.views:
+        body = view.code.rstrip("\n") + "\n"
+        indented_body = textwrap.indent(body, " " * 8)
+        section = (
+            f"    @staticmethod\n"
+            f"    def {view.view_id}() -> dict:\n"
+            f"{indented_body}"
+        )
+        view_sections.append(section)
+
+    if view_sections:
+        rendered_views = "\n\n".join(view_sections) + "\n\n"
+    else:
+        rendered_views = ""
+
+    config_view_lines = []
+    for view in definition.views:
+        config_view_lines.append(f'        "{view.view_id}": Canvas.{view.view_id},')
+    if config_view_lines:
+        config_views = "\n" + "\n".join(config_view_lines) + "\n    "
+    else:
+        config_views = ""
+
+    rendered = (
+        f"{header}    ID = {json.dumps(definition.canvas_id)}\n\n"
+        "    @classmethod\n"
+        "    def render(cls) -> Image.Image:\n"
+        "        return cls._render(CONFIG)\n\n"
+        f"{rendered_views}CONFIG = {{\n"
+        f"    \"name\": {name_literal},\n"
+        f"    \"views\": {{{config_views}}}  # view_id -> view_builder\n"
+        "}\n\n"
+        "if __name__ == \"__main__\":\n"
+        "    img = Canvas.render()\n"
+        "    img.show()\n"
+    )
+    return rendered
+
+
+def _find_canvas_class(module_ast: ast.Module) -> ast.ClassDef:
+    for node in module_ast.body:
+        if isinstance(node, ast.ClassDef) and node.name == "Canvas":
+            return node
+    raise CanvasManagerError("Canvas class not found in module")
+
+
+def _extract_class_id(canvas_class: ast.ClassDef) -> str:
+    for node in canvas_class.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "ID":
+                    if isinstance(node.value, ast.Constant):
+                        return str(node.value.value)
+    raise CanvasManagerError("Canvas ID not defined")
+
+
+def _find_config_assignment(module_ast: ast.Module) -> ast.Assign:
+    for node in module_ast.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "CONFIG":
+                    return node
+    raise CanvasManagerError("CONFIG assignment not found")
+
+
+def _extract_config_metadata(config_assign: ast.Assign) -> tuple[str, List[str]]:
+    if not isinstance(config_assign.value, ast.Dict):
+        raise CanvasManagerError("CONFIG must be a dictionary")
+
+    name = ""
+    view_ids: List[str] = []
+
+    for key_node, value_node in zip(config_assign.value.keys, config_assign.value.values):
+        if isinstance(key_node, ast.Constant) and key_node.value == "name":
+            if isinstance(value_node, ast.Constant):
+                name = str(value_node.value)
+        if isinstance(key_node, ast.Constant) and key_node.value == "views":
+            if isinstance(value_node, ast.Dict):
+                for k in value_node.keys:
+                    if isinstance(k, ast.Constant):
+                        view_ids.append(str(k.value))
+    return name, view_ids
+
+
+def _extract_view_bodies(canvas_class: ast.ClassDef, lines: List[str]) -> Dict[str, str]:
+    view_code: Dict[str, str] = {}
+    for node in canvas_class.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if not any(isinstance(dec, ast.Name) and dec.id == "staticmethod" for dec in node.decorator_list):
+            continue
+        if not node.body:
+            view_code[node.name] = ""
+            continue
+        start = node.body[0].lineno
+        end = node.body[-1].end_lineno
+        body_lines = lines[start - 1:end]
+        code = textwrap.dedent("\n".join(body_lines))
+        if not code.endswith("\n"):
+            code += "\n"
+        view_code[node.name] = code
+    return view_code

--- a/canvas/views/_base_view.py
+++ b/canvas/views/_base_view.py
@@ -10,6 +10,7 @@ class _BaseView(ABC):
         "width": "View Width",
         "height": "View Height",
     }
+    PARAMS = DEFAULT_PARAMS
     
 
     @staticmethod

--- a/canvas/views/circle.py
+++ b/canvas/views/circle.py
@@ -1,0 +1,28 @@
+from PIL import ImageDraw
+
+from ._base_view import _BaseView
+
+
+class CircleView(_BaseView):
+    TYPE = "CircleView"
+
+    PARAMS = {
+        **_BaseView.DEFAULT_PARAMS,
+        "fill": "Fill color for the circle",
+        "outline": "Outline color for the circle",
+    }
+
+    @staticmethod
+    def draw(draw: ImageDraw.ImageDraw, config: dict) -> None:
+        radius_w = config["width"]
+        radius_h = config["height"]
+        x1 = config["location_x"]
+        y1 = config["location_y"]
+        x2 = x1 + radius_w
+        y2 = y1 + radius_h
+        draw.ellipse(
+            [x1, y1, x2, y2],
+            fill=config.get("fill", "#FDE68A"),
+            outline=config.get("outline", "#92400E"),
+            width=2,
+        )

--- a/canvas/views/square.py
+++ b/canvas/views/square.py
@@ -1,0 +1,26 @@
+from PIL import ImageDraw
+
+from ._base_view import _BaseView
+
+
+class SquareView(_BaseView):
+    TYPE = "SquareView"
+
+    PARAMS = {
+        **_BaseView.DEFAULT_PARAMS,
+        "fill": "Fill color for the square",
+        "outline": "Outline color for the square",
+    }
+
+    @staticmethod
+    def draw(draw: ImageDraw.ImageDraw, config: dict) -> None:
+        x1 = config["location_x"]
+        y1 = config["location_y"]
+        x2 = x1 + config["width"]
+        y2 = y1 + config["height"]
+        draw.rectangle(
+            [x1, y1, x2, y2],
+            fill=config.get("fill", "#D1E8FF"),
+            outline=config.get("outline", "#1E3A8A"),
+            width=2,
+        )

--- a/canvas/views/text.py
+++ b/canvas/views/text.py
@@ -1,0 +1,27 @@
+from PIL import ImageDraw, ImageFont
+
+from ._base_view import _BaseView
+
+
+class TextView(_BaseView):
+    TYPE = "TextView"
+
+    PARAMS = {
+        **_BaseView.DEFAULT_PARAMS,
+        "text": "Text to display",
+        "fill": "Text color",
+        "font_size": "Font size in points",
+    }
+
+    @staticmethod
+    def draw(draw: ImageDraw.ImageDraw, config: dict) -> None:
+        text = config.get("text", "Hello")
+        color = config.get("fill", "#111827")
+        font_size = int(config.get("font_size", 18))
+        try:
+            font = ImageFont.truetype("arial.ttf", font_size)
+        except OSError:
+            font = ImageFont.load_default()
+        x = config["location_x"]
+        y = config["location_y"]
+        draw.text((x, y), text, fill=color, font=font)

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,40 +1,546 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Daemon Control</title>
+  <title>Canvas Manager</title>
   <style>
-    body { font-family: Arial, sans-serif; margin: 2em; }
-    button { margin: 0.5em; padding: 0.5em 1em; font-size: 16px; }
-    #status { margin-top: 1em; font-weight: bold; }
+    :root {
+      color-scheme: light dark;
+    }
+
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      margin: 0;
+      padding: 0;
+      background: #f5f5f5;
+      color: #1f2937;
+    }
+
+    header {
+      background: #111827;
+      color: white;
+      padding: 1.5rem 2rem;
+      font-size: 1.75rem;
+      font-weight: 600;
+    }
+
+    main {
+      display: grid;
+      grid-template-columns: 2fr 1fr;
+      gap: 1.5rem;
+      padding: 1.5rem 2rem 3rem 2rem;
+    }
+
+    section {
+      background: white;
+      border-radius: 12px;
+      padding: 1.5rem;
+      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+    }
+
+    h2 {
+      margin-top: 0;
+      font-size: 1.25rem;
+      color: #0f172a;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 0.35rem;
+      font-weight: 600;
+      font-size: 0.9rem;
+      color: #1f2937;
+    }
+
+    select, input[type="text"], textarea {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid #cbd5f5;
+      border-radius: 8px;
+      font-size: 0.95rem;
+      font-family: 'Fira Code', 'Courier New', Courier, monospace;
+      background: #f9fafb;
+      color: #1f2937;
+    }
+
+    textarea {
+      min-height: 160px;
+      line-height: 1.4;
+      resize: vertical;
+      tab-size: 2;
+    }
+
+    button {
+      background: #2563eb;
+      color: white;
+      border: none;
+      border-radius: 8px;
+      padding: 0.5rem 1rem;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.1s ease, box-shadow 0.2s ease;
+      margin-right: 0.5rem;
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 20px rgba(37, 99, 235, 0.35);
+    }
+
+    button.secondary {
+      background: #e5e7eb;
+      color: #1f2937;
+    }
+
+    .row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: flex-end;
+    }
+
+    .row > div {
+      flex: 1 1 200px;
+    }
+
+    .views-container {
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+      margin-top: 1.25rem;
+    }
+
+    .view-card {
+      border: 1px solid #d1d5db;
+      border-radius: 10px;
+      padding: 1rem;
+      background: #f8fafc;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    }
+
+    .view-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 0.75rem;
+    }
+
+    .view-header h3 {
+      margin: 0;
+      font-size: 1.05rem;
+      color: #111827;
+    }
+
+    .view-meta {
+      font-size: 0.85rem;
+      color: #4b5563;
+      margin-top: 0.5rem;
+      background: white;
+      padding: 0.75rem;
+      border-radius: 8px;
+      border: 1px solid #e5e7eb;
+      white-space: pre-wrap;
+    }
+
+    .preview-wrapper {
+      text-align: center;
+    }
+
+    .preview-wrapper img {
+      width: 100%;
+      max-width: 320px;
+      border-radius: 12px;
+      border: 1px solid #d1d5db;
+      background: #ffffff;
+      box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+    }
+
+    .status-text {
+      margin-top: 0.5rem;
+      font-size: 0.9rem;
+      color: #475569;
+    }
+
+    .actions {
+      margin-top: 1rem;
+    }
+
+    .view-controls {
+      display: flex;
+      gap: 0.75rem;
+      margin-bottom: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .view-controls > div {
+      flex: 1 1 200px;
+    }
+
+    @media (max-width: 1024px) {
+      main {
+        grid-template-columns: 1fr;
+      }
+    }
   </style>
 </head>
 <body>
-  <h1>Daemon Controller</h1>
-  <button onclick="startDaemon()">Start</button>
-  <button onclick="stopDaemon()">Stop</button>
-  <div id="status">Status: unknown</div>
+  <header>Canvas Manager</header>
+  <main>
+    <section>
+      <h2>Canvas Selection</h2>
+      <div class="row">
+        <div>
+          <label for="canvas-select">Available canvases</label>
+          <select id="canvas-select"></select>
+        </div>
+        <div>
+          <label for="canvas-name">Canvas name</label>
+          <input type="text" id="canvas-name" placeholder="Enter canvas name">
+        </div>
+      </div>
+      <div class="actions">
+        <button id="save-btn">Save changes</button>
+        <button id="preview-btn" class="secondary">Refresh preview</button>
+      </div>
+      <hr style="margin: 1.5rem 0; border: 0; border-top: 1px solid #e5e7eb;">
+      <h2>Create a new canvas</h2>
+      <div class="row">
+        <div>
+          <label for="new-canvas-id">Canvas ID</label>
+          <input type="text" id="new-canvas-id" placeholder="e.g. my_canvas">
+        </div>
+        <div>
+          <label for="new-canvas-name">Canvas name</label>
+          <input type="text" id="new-canvas-name" placeholder="Friendly name">
+        </div>
+        <div>
+          <button id="create-canvas-btn">Create canvas</button>
+        </div>
+      </div>
+      <hr style="margin: 1.5rem 0; border: 0; border-top: 1px solid #e5e7eb;">
+      <h2>Add view</h2>
+      <div class="row">
+        <div>
+          <label for="new-view-id">View builder ID</label>
+          <input type="text" id="new-view-id" placeholder="e.g. hero_square">
+        </div>
+        <div>
+          <label for="new-view-type">View type</label>
+          <select id="new-view-type"></select>
+        </div>
+        <div>
+          <button id="add-view-btn">Add view</button>
+        </div>
+      </div>
+      <p class="status-text" id="status-text">Select a canvas to begin editing.</p>
+    </section>
+
+    <section>
+      <h2>Live Preview</h2>
+      <div class="preview-wrapper">
+        <img id="canvas-preview" alt="Canvas preview" src="" />
+      </div>
+    </section>
+  </main>
+
+  <main style="padding-top: 0;">
+    <section style="grid-column: 1 / -1;">
+      <h2>Views</h2>
+      <div id="views-container" class="views-container"></div>
+    </section>
+  </main>
 
   <script>
-    async function updateStatus() {
-      const res = await fetch("/status");
-      const data = await res.json();
-      document.getElementById("status").innerText = "Status: " + (data.running ? "Running" : "Stopped");
+    const canvasSelect = document.getElementById('canvas-select');
+    const canvasNameInput = document.getElementById('canvas-name');
+    const statusText = document.getElementById('status-text');
+    const viewsContainer = document.getElementById('views-container');
+    const previewImg = document.getElementById('canvas-preview');
+    const newCanvasIdInput = document.getElementById('new-canvas-id');
+    const newCanvasNameInput = document.getElementById('new-canvas-name');
+    const newViewIdInput = document.getElementById('new-view-id');
+    const newViewTypeSelect = document.getElementById('new-view-type');
+
+    let canvases = [];
+    let availableViews = [];
+    let currentCanvas = null;
+
+    document.getElementById('save-btn').addEventListener('click', saveCanvas);
+    document.getElementById('preview-btn').addEventListener('click', refreshPreview);
+    document.getElementById('create-canvas-btn').addEventListener('click', createCanvas);
+    document.getElementById('add-view-btn').addEventListener('click', addViewToCanvas);
+    canvasSelect.addEventListener('change', () => loadCanvas(canvasSelect.value));
+
+    async function init() {
+      await fetchAvailableViews();
+      await fetchCanvases();
     }
 
-    async function startDaemon() {
-      await fetch("/start", {method: "POST"});
-      updateStatus();
+    function setStatus(message, isError = false) {
+      statusText.textContent = message;
+      statusText.style.color = isError ? '#b91c1c' : '#475569';
     }
 
-    async function stopDaemon() {
-      await fetch("/stop", {method: "POST"});
-      updateStatus();
+    async function fetchAvailableViews() {
+      try {
+        const res = await fetch('/views');
+        const data = await res.json();
+        availableViews = data.views || [];
+        newViewTypeSelect.innerHTML = availableViews
+          .map(view => `<option value="${view.type}">${view.type}</option>`)
+          .join('');
+      } catch (err) {
+        console.error(err);
+        setStatus('Unable to load available views.', true);
+      }
     }
 
-    // Update status every 2s
-    setInterval(updateStatus, 2000);
-    updateStatus();
+    async function fetchCanvases() {
+      try {
+        const res = await fetch('/canvases');
+        const data = await res.json();
+        canvases = data.canvases || [];
+        canvasSelect.innerHTML = canvases
+          .map(canvas => `<option value="${canvas.id}">${canvas.name} (${canvas.id})</option>`)
+          .join('');
+
+        if (canvases.length) {
+          const selectedId = currentCanvas?.id || canvases[0].id;
+          canvasSelect.value = selectedId;
+          await loadCanvas(selectedId);
+        } else {
+          currentCanvas = null;
+          canvasNameInput.value = '';
+          viewsContainer.innerHTML = '';
+          previewImg.src = '';
+          setStatus('No canvases found. Create one to get started.');
+        }
+      } catch (err) {
+        console.error(err);
+        setStatus('Failed to load canvases.', true);
+      }
+    }
+
+    async function loadCanvas(canvasId) {
+      if (!canvasId) return;
+      try {
+        const res = await fetch(`/canvases/${canvasId}`);
+        if (!res.ok) {
+          throw new Error('Unable to load canvas');
+        }
+        const data = await res.json();
+        currentCanvas = {
+          id: data.id,
+          name: data.name,
+          views: data.views.map(view => ({ ...view })),
+          viewConfigs: data.view_configs || [],
+        };
+        canvasNameInput.value = currentCanvas.name;
+        renderViews();
+        refreshPreview();
+        setStatus(`Loaded canvas "${data.name}".`);
+      } catch (err) {
+        console.error(err);
+        setStatus('Failed to load canvas.', true);
+      }
+    }
+
+    function renderViews() {
+      viewsContainer.innerHTML = '';
+      if (!currentCanvas || !currentCanvas.views.length) {
+        const emptyState = document.createElement('p');
+        emptyState.textContent = 'No views defined. Use the form above to add a view.';
+        emptyState.style.color = '#6b7280';
+        viewsContainer.appendChild(emptyState);
+        return;
+      }
+
+      currentCanvas.views.forEach(view => {
+        const card = document.createElement('div');
+        card.className = 'view-card';
+
+        const header = document.createElement('div');
+        header.className = 'view-header';
+
+        const title = document.createElement('h3');
+        title.textContent = `View: ${view.id}`;
+        header.appendChild(title);
+
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = 'Remove';
+        removeBtn.className = 'secondary';
+        removeBtn.addEventListener('click', () => removeView(view.id));
+        header.appendChild(removeBtn);
+
+        const controls = document.createElement('div');
+        controls.className = 'view-controls';
+
+        const idWrapper = document.createElement('div');
+        const idLabel = document.createElement('label');
+        idLabel.textContent = 'View ID (function name)';
+        const idInput = document.createElement('input');
+        idInput.type = 'text';
+        idInput.value = view.id;
+        idInput.addEventListener('input', event => {
+          view.id = event.target.value.trim();
+          title.textContent = `View: ${view.id || '(unnamed)'}`;
+        });
+        idWrapper.appendChild(idLabel);
+        idWrapper.appendChild(idInput);
+        controls.appendChild(idWrapper);
+
+        const editorLabel = document.createElement('label');
+        editorLabel.textContent = 'View builder function body';
+        editorLabel.style.marginTop = '0.75rem';
+
+        const textarea = document.createElement('textarea');
+        textarea.value = view.code;
+        textarea.addEventListener('input', event => {
+          view.code = event.target.value;
+        });
+
+        const meta = document.createElement('div');
+        meta.className = 'view-meta';
+        const configInfo = currentCanvas.viewConfigs?.find(item => item.id === view.id);
+        if (configInfo?.error) {
+          meta.textContent = `Error: ${configInfo.error}`;
+          meta.style.color = '#b91c1c';
+          meta.style.borderColor = '#fecaca';
+        } else if (configInfo?.config) {
+          meta.textContent = JSON.stringify(configInfo.config, null, 2);
+        } else {
+          meta.textContent = 'Configuration preview unavailable. Save to refresh.';
+        }
+
+        card.appendChild(header);
+        card.appendChild(controls);
+        card.appendChild(editorLabel);
+        card.appendChild(textarea);
+        card.appendChild(meta);
+        viewsContainer.appendChild(card);
+      });
+    }
+
+    function removeView(viewId) {
+      if (!currentCanvas) return;
+      currentCanvas.views = currentCanvas.views.filter(view => view.id !== viewId);
+      renderViews();
+    }
+
+    async function saveCanvas() {
+      if (!currentCanvas) {
+        setStatus('Select a canvas before saving.', true);
+        return;
+      }
+      const payload = {
+        name: canvasNameInput.value,
+        views: currentCanvas.views.map(view => ({
+          id: view.id,
+          code: view.code,
+        })),
+      };
+
+      try {
+        const res = await fetch(`/canvases/${currentCanvas.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) {
+          const errorBody = await res.json();
+          throw new Error(errorBody.detail || 'Failed to save canvas');
+        }
+        const data = await res.json();
+        currentCanvas = {
+          id: data.id,
+          name: data.name,
+          views: data.views.map(view => ({ ...view })),
+          viewConfigs: data.view_configs || [],
+        };
+        canvasNameInput.value = currentCanvas.name;
+        renderViews();
+        refreshPreview();
+        await fetchCanvases();
+        canvasSelect.value = currentCanvas.id;
+        setStatus('Canvas saved successfully.');
+      } catch (err) {
+        console.error(err);
+        setStatus(err.message || 'Failed to save canvas.', true);
+      }
+    }
+
+    async function createCanvas() {
+      const id = newCanvasIdInput.value.trim();
+      const name = newCanvasNameInput.value.trim();
+      if (!id || !name) {
+        setStatus('Provide both an ID and a name to create a canvas.', true);
+        return;
+      }
+      try {
+        const res = await fetch('/canvases', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ canvas_id: id, name }),
+        });
+        if (!res.ok) {
+          const errorBody = await res.json();
+          throw new Error(errorBody.detail || 'Failed to create canvas');
+        }
+        newCanvasIdInput.value = '';
+        newCanvasNameInput.value = '';
+        setStatus(`Canvas "${name}" created. Select it from the list.`);
+        await fetchCanvases();
+        canvasSelect.value = id;
+        await loadCanvas(id);
+      } catch (err) {
+        console.error(err);
+        setStatus(err.message || 'Failed to create canvas.', true);
+      }
+    }
+
+    function addViewToCanvas() {
+      if (!currentCanvas) {
+        setStatus('Select a canvas before adding views.', true);
+        return;
+      }
+      const viewId = newViewIdInput.value.trim();
+      const viewType = newViewTypeSelect.value;
+      if (!viewId || !viewType) {
+        setStatus('Provide both a view ID and a view type.', true);
+        return;
+      }
+      if (currentCanvas.views.some(view => view.id === viewId)) {
+        setStatus('A view with that ID already exists.', true);
+        return;
+      }
+      const defaultCode = getDefaultViewCode(viewType);
+      currentCanvas.views.push({ id: viewId, code: defaultCode });
+      newViewIdInput.value = '';
+      renderViews();
+      setStatus(`Added view "${viewId}". Remember to save your changes.`);
+    }
+
+    function getDefaultViewCode(viewType) {
+      switch (viewType) {
+        case 'SquareView':
+          return `return {\n    "type": "SquareView",\n    "location_x": 20,\n    "location_y": 20,\n    "width": 80,\n    "height": 80,\n    "fill": "#D1E8FF",\n    "outline": "#1E3A8A",\n}`;
+        case 'CircleView':
+          return `return {\n    "type": "CircleView",\n    "location_x": 40,\n    "location_y": 40,\n    "width": 72,\n    "height": 72,\n    "fill": "#FDE68A",\n    "outline": "#92400E",\n}`;
+        case 'TextView':
+          return `return {\n    "type": "TextView",\n    "location_x": 16,\n    "location_y": 32,\n    "width": 120,\n    "height": 40,\n    "text": "Hello world",\n    "fill": "#111827",\n    "font_size": 18,\n}`;
+        default:
+          return `return {\n    "type": "${viewType}",\n    "location_x": 0,\n    "location_y": 0,\n    "width": 100,\n    "height": 100,\n}`;
+      }
+    }
+
+    function refreshPreview() {
+      if (!currentCanvas) return;
+      previewImg.src = `/canvases/${currentCanvas.id}/preview?ts=${Date.now()}`;
+    }
+
+    init();
   </script>
 </body>
 </html>

--- a/server.py
+++ b/server.py
@@ -1,34 +1,115 @@
-from fastapi import FastAPI, BackgroundTasks, Request
+from io import BytesIO
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
-import asyncio
+from pydantic import BaseModel
+
+from canvas.canvas_manager import (
+    CanvasManagerError,
+    CanvasNotFoundError,
+    create_canvas,
+    list_available_views,
+    list_canvases,
+    load_canvas,
+    load_view_configs,
+    render_canvas,
+    save_canvas,
+)
+
 
 app = FastAPI()
 app.mount("/ui", StaticFiles(directory="pages", html=True), name="pages")
 
-running = False
 
-async def daemon_task():
-    global running
-    while running:
-        # Your daemon logic goes here
-        print("Daemon working...")
-        await asyncio.sleep(5)
+class ViewPayload(BaseModel):
+    id: str
+    code: str
 
-@app.post("/start")
-async def start_daemon(background_tasks: BackgroundTasks):
-    global running
-    if not running:
-        running = True
-        background_tasks.add_task(daemon_task)
-    return {"status": "started"}
 
-@app.post("/stop")
-async def stop_daemon():
-    global running
-    running = False
-    return {"status": "stopped"}
+class CanvasUpdatePayload(BaseModel):
+    name: str
+    views: List[ViewPayload]
 
-@app.get("/status")
-def get_status():
-    return {"running": running}
+
+class CanvasCreatePayload(BaseModel):
+    canvas_id: str
+    name: str
+
+
+@app.get("/canvases")
+def get_canvases():
+    return {"canvases": list_canvases()}
+
+
+@app.get("/canvases/{canvas_id}")
+def get_canvas(canvas_id: str):
+    try:
+        definition = load_canvas(canvas_id)
+    except CanvasNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    view_configs = load_view_configs(canvas_id)
+    return {
+        "id": definition.canvas_id,
+        "name": definition.name,
+        "views": [{"id": view.view_id, "code": view.code} for view in definition.views],
+        "view_configs": view_configs,
+    }
+
+
+@app.post("/canvases")
+def create_canvas_endpoint(payload: CanvasCreatePayload):
+    try:
+        definition = create_canvas(payload.canvas_id, payload.name)
+    except CanvasManagerError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {
+        "id": definition.canvas_id,
+        "name": definition.name,
+        "views": [],
+    }
+
+
+@app.put("/canvases/{canvas_id}")
+def update_canvas(canvas_id: str, payload: CanvasUpdatePayload):
+    try:
+        updated = save_canvas(
+            canvas_id,
+            payload.name,
+            [{"id": view.id, "code": view.code} for view in payload.views],
+        )
+    except CanvasNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except CanvasManagerError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    view_configs = load_view_configs(canvas_id)
+    return {
+        "id": updated.canvas_id,
+        "name": updated.name,
+        "views": [{"id": view.view_id, "code": view.code} for view in updated.views],
+        "view_configs": view_configs,
+    }
+
+
+@app.get("/canvases/{canvas_id}/preview")
+def preview_canvas(canvas_id: str):
+    try:
+        image = render_canvas(canvas_id)
+    except CanvasNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except CanvasManagerError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    buffer.seek(0)
+    return StreamingResponse(buffer, media_type="image/png")
+
+
+@app.get("/views")
+def get_available_views():
+    return {"views": list_available_views()}
 


### PR DESCRIPTION
## Summary
- add a `canvas_manager` package to read, create, and update canvas modules from the template
- expose canvas CRUD and preview endpoints together with view metadata in the FastAPI server
- implement reusable square, circle, and text views and refresh `canvas1` to use them
- replace the daemon control page with an interactive canvas editor that includes code editors and a live preview

## Testing
- python -m compileall dotcanvas
- uvicorn server:app --host 0.0.0.0 --port 8000 (manual smoke test for the UI)


------
https://chatgpt.com/codex/tasks/task_e_68df6d912e4883298e7ace3079d9c2fd