### PR TITLE
Migrate Dot Image API to authV2 device endpoint

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 import logging
 import requests
@@ -6,8 +7,12 @@ import requests
 logger = logging.getLogger("dot.api")
 
 class APIClient:
-    def __init__(self, key: str, base_url: str = "https://dot.mindreset.tech/api/open/image") -> None:
-        self.base_url = base_url
+    def __init__(
+        self,
+        key: str,
+        base_url: str = "https://dot.mindreset.tech/api/authV2/open/device",
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
         self.key = key
 
     def send_image(
@@ -20,11 +25,12 @@ class APIClient:
         border: int = 0,
         dither_type: str = "DIFFUSION",
         dither_kernel: str = "FLOYD_STEINBERG",
+        task_key: Optional[str] = None,
+        task_alias: Optional[str | int] = None,
         timeout: Optional[float] = 10.0,
     ) -> Optional[Dict[str, Any]]:
         payload: Dict[str, Any] = {
             "refreshNow": refresh_now,
-            "deviceId": device_id,
             "image": image,
             "border": border,
             "ditherType": dither_type,
@@ -33,14 +39,19 @@ class APIClient:
 
         if link:
             payload["link"] = link
+        if task_key is not None:
+            payload["taskKey"] = task_key
+        if task_alias is not None:
+            payload["taskAlias"] = task_alias
 
         headers = {
             "Authorization": f"Bearer {self.key}",
             "Content-Type": "application/json",
         }
 
+        url = f"{self.base_url}/{quote(device_id, safe='')}/image"
         response = requests.post(
-            self.base_url,
+            url,
             headers=headers,
             json=payload,
             timeout=timeout,
@@ -48,6 +59,9 @@ class APIClient:
         response.raise_for_status()
 
         if response.status_code == 204 or not response.content:
-            logger.error(f"api error ({response.status_code}): {response.json()}")
+            logger.error(f"api error ({response.status_code}): empty response")
+            return None
 
-        logger.debug(f"Success ({response.status_code}): {response.json()}")
+        data = response.json()
+        logger.debug(f"Success ({response.status_code}): {data}")
+        return data


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Updates the Dot Image API client from the deprecated legacy endpoint to the current authV2 path-based API.

### Changes
- **Endpoint**: `POST /api/open/image` → `POST /api/authV2/open/device/:deviceId/image`
- **`deviceId`**: removed from request body; now placed in the URL path
- **Optional params**: added support for `taskKey` and `taskAlias` from the new API schema
- Existing callers (`daemon.py`) remain compatible — they already pass `device_id` as a keyword argument

### Request body (unchanged fields)
`refreshNow`, `image`, `link`, `border`, `ditherType`, `ditherKernel`

Refs: https://dot.mindreset.tech/docs/service/open/image_api

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef001210-f3ab-474f-8192-5569157a013f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef001210-f3ab-474f-8192-5569157a013f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

