### PR TITLE
Fix calendar preview crash and uv pip bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ wheels/
 # Virtual environments
 .venv
 
+# Runtime-installed packages for canvas views
+user_site/
+
 # IDE files
 .vscode/
 .idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+DotCanvas is a lightweight canvas editor for the "Dot." e-ink device. It has two parts:
+
+- Backend: FastAPI app in `server.py` (Python 3.12, managed with `uv`), run via `uvicorn`. It renders 296x152 PNG previews with Pillow/cairosvg and runs a scheduling daemon (APScheduler). System libs for cairosvg (cairo/pango/gdk-pixbuf/libffi) are preinstalled on the base image.
+- Frontend: Vite + React SPA in `frontend/` (Node), served under the `/ui` base path.
+
+The startup update script already runs `uv sync` (backend deps into `.venv`) and `npm install` in `frontend/`. Standard run/build commands live in `README.md` and `frontend/package.json`; prefer those. Notes below are non-obvious gotchas.
+
+### Running the services
+- Backend (dev, hot reload): `source .venv/bin/activate && uvicorn server:app --host 0.0.0.0 --port 8000 --reload`
+- Frontend build (needed to serve the UI through the backend): `cd frontend && npm run build` — outputs `frontend/dist/` (gitignored). The backend serves the built SPA at `http://localhost:8000/ui/daemon`.
+- Frontend dev server (HMR for UI shell): `cd frontend && npm run dev` → `http://localhost:5173/ui/`.
+
+### Non-obvious gotchas
+- The Vite dev server (`:5173`) does NOT proxy API calls. The React app fetches relative paths like `/canvases`, `/config`, so those requests hit `:5173` and 404. To exercise the full app end-to-end (canvas editing, preview, daemon, config), run `npm run build` and use the backend-served UI at `http://localhost:8000/ui/...`. The `:5173` dev server is only useful for iterating on non-API UI.
+- `configs/config.yaml` is gitignored and required for the daemon/config features. Create it once with `cp configs/config-example.yaml configs/config.yaml`. If missing, the server still boots but `dot_daemon` is `None` and `/config` returns 404.
+- Canvas definitions are Python modules written to `canvas/*.py` at runtime and are gitignored (except the demo canvases and templates). Creating/editing a canvas in the UI writes files to disk; live preview only refreshes after saving.
+- There is no automated test suite and no configured linter (ESLint is a listed frontend dep but has no config or `lint` script). Validate changes by running the app and rendering previews.
+- Canvas views can install extra Python packages at runtime via `install_package(...)` into a gitignored `user_site/` directory; `uv` venvs omit pip, so the package manager bootstraps pip via `ensurepip` on first use.

--- a/README.md
+++ b/README.md
@@ -21,12 +21,111 @@ DotCanvas 是一个轻量级的可视化Dot.编辑工具。
 # 拉取镜像
 docker pull ghcr.io/lucasxingg/dotcanvas:latest
 
-# 运行容器，映射端口并挂载配置目录
-docker run -d -p 8000:8000 ghcr.io/lucasxingg/dotcanvas:latest
+# 运行容器（映射端口；建议同时挂载 configs 与 canvas，见下方「持久化」章节）
+docker run -d \
+  --name dotcanvas \
+  -p 8000:8000 \
+  -v $(pwd)/configs:/app/configs \
+  -v $(pwd)/canvas:/app/canvas \
+  ghcr.io/lucasxingg/dotcanvas:latest
 ```
 
 容器启动后，通过 <http://localhost:8000/> 访问管理界面。
 当你需要更新配置时，直接编辑宿主机 `configs/config.yaml` 并重启容器即可。
+
+> 若不挂载卷，画布与配置只存在于容器可写层中；拉取新镜像并重建容器后会全部丢失。请务必按下一节挂载数据卷。
+
+## 持久化画布与配置（镜像更新后不丢失）
+
+在 DotCanvas 中：
+
+- **自定义画布**保存为 `canvas/<画布ID>.py`（Web 界面里创建/编辑时会写回磁盘）。
+- **服务配置与 API 令牌**保存在 `configs/`（如 `config.yaml`、`tokens.json`）。
+- **运行时安装的 Python 包**（视图里调用 `install_package(...)`）落在 `user_site/`。
+
+镜像只提供程序与内置 demo 画布；真正属于你的数据必须挂到宿主机，否则更新镜像后会消失。
+
+### 推荐启动方式（挂载数据目录）
+
+若你是从本仓库部署，可直接挂载仓库里的 `configs/` 与 `canvas/`：
+
+```bash
+# 首次准备配置（仅一次）
+cp -n configs/config-example.yaml configs/config.yaml
+
+docker run -d \
+  --name dotcanvas \
+  -p 8000:8000 \
+  -v $(pwd)/configs:/app/configs \
+  -v $(pwd)/canvas:/app/canvas \
+  ghcr.io/lucasxingg/dotcanvas:latest
+```
+
+若你只有预构建镜像、本地还没有 `canvas/` 目录，可先从镜像拷出完整 `canvas`（含框架文件与 demo），再挂载：
+
+```bash
+mkdir -p configs canvas
+docker create --name dotcanvas-seed ghcr.io/lucasxingg/dotcanvas:latest
+docker cp dotcanvas-seed:/app/canvas/. ./canvas/
+docker cp dotcanvas-seed:/app/configs/config-example.yaml ./configs/config-example.yaml
+docker rm dotcanvas-seed
+cp -n configs/config-example.yaml configs/config.yaml
+
+docker run -d \
+  --name dotcanvas \
+  -p 8000:8000 \
+  -v $(pwd)/configs:/app/configs \
+  -v $(pwd)/canvas:/app/canvas \
+  ghcr.io/lucasxingg/dotcanvas:latest
+```
+
+此后在 UI 中新建的画布都会写到宿主机的 `canvas/`，重启或换容器不会丢。
+
+可选：若视图使用了 `install_package()`，可再挂载 `-v $(pwd)/user_site:/app/user_site`，避免重建容器后重新下载依赖。
+
+### 更新镜像时保留自己的画布
+
+```bash
+# 1. 拉取新镜像
+docker pull ghcr.io/lucasxingg/dotcanvas:latest
+
+# 2. 用相同的卷挂载重建容器
+docker stop dotcanvas && docker rm dotcanvas
+docker run -d \
+  --name dotcanvas \
+  -p 8000:8000 \
+  -v $(pwd)/configs:/app/configs \
+  -v $(pwd)/canvas:/app/canvas \
+  ghcr.io/lucasxingg/dotcanvas:latest
+```
+
+只要 `-v .../canvas:/app/canvas` 指向的是同一宿主机目录，你自定义的 `*.py` 画布文件会原样保留。
+
+### 注意事项
+
+- **必须挂载完整的 `canvas` 目录**，不能只挂某一个 `.py`。运行时依赖同目录下的 `_base_canvas.py`、`_canvas_template.py`、`views/`、`canvas_manager/` 等框架文件；挂载会覆盖镜像内的 `/app/canvas`。
+- **你的画布**：宿主机 `canvas/` 下不以 `_` 开头的 `*.py`（例如 `hello_world.py`）。请勿删除或覆盖这些文件。
+- **框架文件也可能随版本更新**：若新镜像改了 `views/` 或 `_base_canvas.py` 等，而你挂载的是旧的宿主机 `canvas/`，容器会继续用旧框架。更新后如遇异常，可从新镜像把框架文件同步回来，同时**保留自己的画布文件**：
+
+```bash
+docker create --name dotcanvas-new ghcr.io/lucasxingg/dotcanvas:latest
+# 备份当前挂载目录中的画布模块
+mkdir -p canvas-backup && cp canvas/*.py canvas-backup/ 2>/dev/null || true
+# 用新镜像中的 canvas 覆盖框架（含 views/ 等）
+docker cp dotcanvas-new:/app/canvas/. ./canvas/
+docker rm dotcanvas-new
+# 把备份里自己的画布拷回去（跳过以下划线开头的框架/模板文件）
+for f in canvas-backup/*.py; do
+  [ -f "$f" ] || continue
+  base=$(basename "$f")
+  case "$base" in
+    _*|__init__.py) ;; # 保留新镜像中的框架文件
+    *) cp "$f" "canvas/$base" ;;
+  esac
+done
+```
+
+- `configs/` 含 API key 与令牌，请妥善保管挂载目录的权限。
 
 ## 手动构建 Docker 镜像部署
 
@@ -40,8 +139,9 @@ cp configs/config-example.yaml configs/config.yaml
 # 构建镜像
 docker build -t dotcanvas .
 
-# 运行容器，映射端口并挂载配置目录
+# 运行容器，映射端口并挂载配置与画布目录（更新镜像后数据仍保留）
 docker run -d \
+  --name dotcanvas \
   -p 8000:8000 \
   -v $(pwd)/configs:/app/configs \
   -v $(pwd)/canvas:/app/canvas \
@@ -49,7 +149,7 @@ docker run -d \
 ```
 
 容器启动后，同样通过 <http://localhost:8000/> 访问管理界面。
-当你需要更新配置时，直接编辑宿主机 `configs/config.yaml` 并重启容器即可。
+当你需要更新配置时，直接编辑宿主机 `configs/config.yaml` 并重启容器即可。画布持久化与镜像更新步骤见上一节。
 
 ## 本地部署
 

--- a/canvas/_base_canvas.py
+++ b/canvas/_base_canvas.py
@@ -26,6 +26,7 @@ class _BaseCanvas():
         params_dict: dict[str, Any] = params or {}
 
         for view_builder in config["views"].values():
+            view_config = None
             try:
                 view_config = cls._invoke_view_builder(view_builder, params_dict)
                 view_cls = available_views.get(view_config["type"])

--- a/canvas/_package_manager.py
+++ b/canvas/_package_manager.py
@@ -85,6 +85,14 @@ def install_package(*packages: str) -> None:
         # logger.info("Packages %s already installed; skipping", normalized)
         return
 
+    logger.info("Installing packages %s into %s", to_install, user_site)
+    _run_pip_install(to_install, user_site)
+    importlib.invalidate_caches()
+    _save_manifest(manifest, installed.union(to_install))
+
+
+def _run_pip_install(packages: list[str], user_site: Path) -> None:
+    """Install packages with `python -m pip`, bootstrapping pip if needed."""
     cmd = [
         sys.executable,
         "-m",
@@ -93,13 +101,52 @@ def install_package(*packages: str) -> None:
         "--no-cache-dir",
         "--target",
         str(user_site),
+        *packages,
     ]
-    cmd.extend(to_install)
 
-    logger.info("Installing packages %s into %s", to_install, user_site)
-    subprocess.check_call(cmd)
-    importlib.invalidate_caches()
-    _save_manifest(manifest, installed.union(to_install))
+    try:
+        subprocess.check_call(cmd)
+        return
+    except subprocess.CalledProcessError as exc:
+        # uv-managed venvs often omit pip; bootstrap it once and retry.
+        if not _ensure_pip_available():
+            raise
+        logger.info("Retrying package install after bootstrapping pip")
+        try:
+            subprocess.check_call(cmd)
+        except subprocess.CalledProcessError:
+            raise exc from None
+
+
+def _ensure_pip_available() -> bool:
+    """Return True when `python -m pip` works, installing pip if necessary."""
+    probe = subprocess.run(
+        [sys.executable, "-m", "pip", "--version"],
+        capture_output=True,
+        check=False,
+    )
+    if probe.returncode == 0:
+        return True
+
+    logger.warning("pip is unavailable in %s; attempting bootstrap", sys.executable)
+    bootstrap = subprocess.run(
+        [sys.executable, "-m", "ensurepip", "--upgrade"],
+        capture_output=True,
+        check=False,
+    )
+    if bootstrap.returncode != 0:
+        logger.error(
+            "Failed to bootstrap pip via ensurepip: %s",
+            bootstrap.stderr.decode(errors="ignore").strip() or bootstrap.stdout.decode(errors="ignore").strip(),
+        )
+        return False
+
+    probe = subprocess.run(
+        [sys.executable, "-m", "pip", "--version"],
+        capture_output=True,
+        check=False,
+    )
+    return probe.returncode == 0
 
 
 def install_packages(packages: Iterable[str]) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
While deploying and verifying `dev` locally, two issues blocked full canvas functionality:

1. **`calendar_canvas` preview returned HTTP 500** — if a view builder raised before assigning `view_config`, `_BaseCanvas._render` hit `UnboundLocalError` and aborted the whole render instead of skipping the failed view.
2. **`install_package()` failed in uv venvs** — `python -m pip` is often missing under uv, so `calendar_canvas.event_text` (and any view using `install_package`) could not install runtime deps like `caldav` / `icalendar`.

## Changes
- Initialize `view_config = None` before invoking builders so render failures are logged and skipped.
- Bootstrap pip via `ensurepip` when `python -m pip` is unavailable, then retry the install.
- Ignore runtime `user_site/` directory.

## Verification
Local deploy of `dev` on this machine passed after the fixes:
- UI routes (`/`, `/ui/*`, `/docs`)
- Canvas CRUD + preview (builtin + multi-view covering Square/Circle/Text/ProgressBar/LucideIcon/DigitalClock/AnalogClock/Triangle/Weather/Image)
- Daemon start/stop/restart/status
- Config get/put
- Token create/list/delete + API auth
- `/api/schedules/trigger` and `/api/devices/send-canvas` local pipeline (external Dot API correctly returns 401 with placeholder API key)

[countdown preview](https://cursor.com/agents/bc-4490ff98-7e50-4399-ad37-e99c59f83f28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_countdown_canvas.png)
[calendar preview](https://cursor.com/agents/bc-4490ff98-7e50-4399-ad37-e99c59f83f28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_calendar_canvas.png)
[all views preview](https://cursor.com/agents/bc-4490ff98-7e50-4399-ad37-e99c59f83f28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpreview_all_views.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4490ff98-7e50-4399-ad37-e99c59f83f28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4490ff98-7e50-4399-ad37-e99c59f83f28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

