### PR TITLE
Add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+DotCanvas is a lightweight canvas editor for the "Dot." e-ink device. It has two parts:
+
+- Backend: FastAPI app in `server.py` (Python 3.12, managed with `uv`), run via `uvicorn`. It renders 296x152 PNG previews with Pillow/cairosvg and runs a scheduling daemon (APScheduler). System libs for cairosvg (cairo/pango/gdk-pixbuf/libffi) are preinstalled on the base image.
+- Frontend: Vite + React SPA in `frontend/` (Node), served under the `/ui` base path.
+
+The startup update script already runs `uv sync` (backend deps into `.venv`) and `npm install` in `frontend/`. Standard run/build commands live in `README.md` and `frontend/package.json`; prefer those. Notes below are non-obvious gotchas.
+
+### Running the services
+- Backend (dev, hot reload): `source .venv/bin/activate && uvicorn server:app --host 0.0.0.0 --port 8000 --reload`
+- Frontend build (needed to serve the UI through the backend): `cd frontend && npm run build` — outputs `frontend/dist/` (gitignored). The backend serves the built SPA at `http://localhost:8000/ui/daemon`.
+- Frontend dev server (HMR for UI shell): `cd frontend && npm run dev` → `http://localhost:5173/ui/`.
+
+### Non-obvious gotchas
+- The Vite dev server (`:5173`) does NOT proxy API calls. The React app fetches relative paths like `/canvases`, `/config`, so those requests hit `:5173` and 404. To exercise the full app end-to-end (canvas editing, preview, daemon, config), run `npm run build` and use the backend-served UI at `http://localhost:8000/ui/...`. The `:5173` dev server is only useful for iterating on non-API UI.
+- `configs/config.yaml` is gitignored and required for the daemon/config features. Create it once with `cp configs/config-example.yaml configs/config.yaml`. If missing, the server still boots but `dot_daemon` is `None` and `/config` returns 404.
+- Canvas definitions are Python modules written to `canvas/*.py` at runtime and are gitignored (except the demo canvases and templates). Creating/editing a canvas in the UI writes files to disk; live preview only refreshes after saving.
+- There is no automated test suite and no configured linter (ESLint is a listed frontend dep but has no config or `lint` script). Validate changes by running the app and rendering previews.
+- Canvas views can install extra Python packages at runtime via `install_package(...)` into a gitignored `user_site/` directory; `uv` venvs omit pip, so the package manager bootstraps pip via `ensurepip` on first use.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the DotCanvas development environment for Cursor Cloud agents and documents non-obvious startup caveats in `AGENTS.md`. No application code changes.

## Environment setup

- Backend: Python 3.12 + `uv` (`uv sync` into `.venv`), run with `uvicorn server:app --reload`. cairo/pango/gdk-pixbuf/libffi system libs are preinstalled.
- Frontend: Vite + React (`npm install` / `npm run build` / `npm run dev`).
- `configs/config.yaml` created from `configs/config-example.yaml`.

Update script (runs on VM startup):
```
uv sync
npm install --prefix frontend
```

## Verification (hello-world)

Started the backend (`:8000`) and Vite dev server (`:5173`), then used the backend-served UI to create a new `hello_world` canvas, added a `TextView`, and confirmed the live preview rendered "Hello World" as a 296×152 PNG. Also confirmed the `calendar_canvas`/`countdown_canvas` previews render (200, valid PNGs).

[dotcanvas_create_canvas_and_render_preview.mp4](https://cursor.com/agents/bc-00a5ab93-fb9d-4de8-9071-de22a4255640/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdotcanvas_create_canvas_and_render_preview.mp4)

[Rendered hello_world preview](https://cursor.com/agents/bc-00a5ab93-fb9d-4de8-9071-de22a4255640/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_rendered_preview.webp)

## Key gotcha documented

The Vite dev server (`:5173`) does not proxy API calls, so API-backed pages 404 there; the full app works end-to-end only through the backend-served UI at `http://localhost:8000/ui/...` (requires `npm run build`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00a5ab93-fb9d-4de8-9071-de22a4255640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00a5ab93-fb9d-4de8-9071-de22a4255640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

