### PR TITLE
Fix send_image empty/204 response handling

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -50,18 +50,35 @@ class APIClient:
         }
 
         url = f"{self.base_url}/{quote(device_id, safe='')}/image"
-        response = requests.post(
-            url,
-            headers=headers,
-            json=payload,
-            timeout=timeout,
-        )
-        response.raise_for_status()
-
-        if response.status_code == 204 or not response.content:
-            logger.error(f"api error ({response.status_code}): empty response")
+        try:
+            response = requests.post(
+                url,
+                headers=headers,
+                json=payload,
+                timeout=timeout,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            detail = ""
+            if getattr(exc, "response", None) is not None:
+                detail = (exc.response.text or "").strip()
+            if status is not None:
+                logger.error("api error (%s): %s", status, detail or exc)
+            else:
+                logger.error("api error: %s", exc)
             return None
 
-        data = response.json()
-        logger.debug(f"Success ({response.status_code}): {data}")
+        # 204 / empty body is a successful no-content response — not an error
+        if response.status_code == 204 or not response.content:
+            logger.debug("Success (%s): empty response", response.status_code)
+            return None
+
+        try:
+            data = response.json()
+        except ValueError:
+            logger.error("api error (%s): invalid JSON response", response.status_code)
+            return None
+
+        logger.debug("Success (%s): %s", response.status_code, data)
         return data


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Treat HTTP 204 / empty response bodies from the Image API as successful no-content (debug log only, return `None`).
- Catch request failures and invalid JSON, log `api error ...` for the daemon Recent logs / message box, and return `None` without raising so callers are not disrupted.

## Test plan
- [x] Unit-style mocks: 204 and empty 200 do not call `logger.error`
- [x] Unit-style mocks: 200 JSON still returns parsed payload
- [x] Unit-style mocks: 401 logs `api error` and returns `None` without raising

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb193-a3c9-7dad-9e35-fd7eeb2f92e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb193-a3c9-7dad-9e35-fd7eeb2f92e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

