### PR TITLE
Fix install_package native builds and document Github vs PyGithub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,13 @@ RUN npm run build
 
 FROM python:3.12-slim AS base
 
-# Install system dependencies required for cairosvg and friends
+# Runtime libs for cairosvg; build tools so install_package() can compile
+# C-extension sdists when no compatible wheel exists for the current Python.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        build-essential \
+        gcc \
+        g++ \
         libcairo2 \
         libpango-1.0-0 \
         libpangocairo-1.0-0 \

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ npm run dev
 - 对于视图构造函数，所有变量都需要包含在返回字典中，除非另行声明。
 - 实时预览只会在保存修改后（点击`保存更改`按钮或使用快捷键`command + s`）更新。
 - [视图文档](docs/views/index.md)
-- 如果需要使用额外的包，可以使用`install_package()`方法来安装一个或多个包，例如`install_package("numpy", "pandas")`
+- 如果需要使用额外的包，可以使用`install_package()`方法来安装一个或多个包，例如`install_package("numpy", "pandas")`。包会装到 `user_site/`；优先选择提供 Python 3.12 预编译 wheel 的包。Docker 镜像已包含编译工具，必要时可从源码构建 C 扩展。注意：PyPI 上的包名 `Github` 固定依赖过旧的 `aiohttp==3.8.1`，在 Python 3.12 上无法安装；访问 GitHub API 请使用 `install_package("PyGithub")`。
 
 ## 配置管理
 - API密钥：在 Dot. APP 中生成
@@ -205,6 +205,13 @@ npm run dev
 - 修改配置后需要在进程控制页面重启守护进程。
 
 # 故障排除
+
+## `install_package()` 构建失败（例如缺少 gcc / Failed building wheel）
+
+常见原因：
+
+1. 依赖只有源码包（sdist）、没有当前 Python 的预编译 wheel，需要本地编译。Docker 镜像已包含 `build-essential`；本地开发请自行安装编译器（如 `build-essential` / Xcode CLT）。
+2. 包本身与 Python 3.12 不兼容。典型例子：`install_package("Github")` 会拉取 `aiohttp==3.8.1`（无 cp312 wheel，且不支持 3.12）。若需要 GitHub API，请改用 `install_package("PyGithub")`。
 
 ## 在 macOS 下出现与 Cairo 相关报错
 尝试安装对应库

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ npm run dev
 - 对于视图构造函数，所有变量都需要包含在返回字典中，除非另行声明。
 - 实时预览只会在保存修改后（点击`保存更改`按钮或使用快捷键`command + s`）更新。
 - [视图文档](docs/views/index.md)
-- 如果需要使用额外的包，可以使用`install_package()`方法来安装一个或多个包，例如`install_package("numpy", "pandas")`。包会装到 `user_site/`；优先选择提供 Python 3.12 预编译 wheel 的包。Docker 镜像已包含编译工具，必要时可从源码构建 C 扩展。注意：PyPI 上的包名 `Github` 固定依赖过旧的 `aiohttp==3.8.1`，在 Python 3.12 上无法安装；访问 GitHub API 请使用 `install_package("PyGithub")`。
+- 如果需要使用额外的包，可以使用`install_package()`方法来安装一个或多个包，例如`install_package("numpy", "pandas")`。包会装到 `user_site/`；优先选择提供 Python 3.12 预编译 wheel 的包。Docker 镜像已包含编译工具，必要时可从源码构建 C 扩展。
 
 ## 配置管理
 - API密钥：在 Dot. APP 中生成
@@ -208,10 +208,7 @@ npm run dev
 
 ## `install_package()` 构建失败（例如缺少 gcc / Failed building wheel）
 
-常见原因：
-
-1. 依赖只有源码包（sdist）、没有当前 Python 的预编译 wheel，需要本地编译。Docker 镜像已包含 `build-essential`；本地开发请自行安装编译器（如 `build-essential` / Xcode CLT）。
-2. 包本身与 Python 3.12 不兼容。典型例子：`install_package("Github")` 会拉取 `aiohttp==3.8.1`（无 cp312 wheel，且不支持 3.12）。若需要 GitHub API，请改用 `install_package("PyGithub")`。
+常见原因：依赖只有源码包（sdist）、没有当前 Python 的预编译 wheel，需要本地编译；或包本身与 Python 3.12 不兼容。Docker 镜像已包含 `build-essential`；本地开发请自行安装编译器（如 `build-essential` / Xcode CLT）。
 
 ## 在 macOS 下出现与 Cairo 相关报错
 尝试安装对应库

--- a/src/canvas_runtime/package_manager.py
+++ b/src/canvas_runtime/package_manager.py
@@ -151,9 +151,7 @@ def _pip_install_error(
     hint = (
         f"Failed to install {packages!r} into user_site for Python {py_tag}. "
         "Prefer packages that publish binary wheels for this Python version; "
-        "source builds need a compiler (Docker images include build-essential). "
-        "Note: the PyPI package 'Github' pins aiohttp==3.8.1 and is incompatible "
-        "with Python 3.12+ — use 'PyGithub' for the GitHub API instead."
+        "source builds need a compiler (Docker images include build-essential)."
     )
     if detail:
         return RuntimeError(f"{hint}\n\nPip output (tail):\n{detail}")

--- a/src/canvas_runtime/package_manager.py
+++ b/src/canvas_runtime/package_manager.py
@@ -100,23 +100,64 @@ def _run_pip_install(packages: list[str], user_site: Path) -> None:
         "pip",
         "install",
         "--no-cache-dir",
+        "--prefer-binary",
         "--target",
         str(user_site),
         *packages,
     ]
 
     try:
-        subprocess.check_call(cmd)
+        _invoke_pip(cmd)
         return
     except subprocess.CalledProcessError as exc:
         # uv-managed venvs often omit pip; bootstrap it once and retry.
         if not _ensure_pip_available():
-            raise
+            raise _pip_install_error(packages, exc) from exc
         logger.info("Retrying package install after bootstrapping pip")
         try:
-            subprocess.check_call(cmd)
-        except subprocess.CalledProcessError:
-            raise exc from None
+            _invoke_pip(cmd)
+        except subprocess.CalledProcessError as retry_exc:
+            raise _pip_install_error(packages, retry_exc) from retry_exc
+
+
+def _invoke_pip(cmd: list[str]) -> None:
+    """Run pip and surface its combined output on failure."""
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode == 0:
+        if result.stdout.strip():
+            logger.info(result.stdout.rstrip())
+        return
+    combined = "\n".join(
+        part for part in (result.stdout, result.stderr) if part and part.strip()
+    ).strip()
+    if combined:
+        logger.error(combined)
+    raise subprocess.CalledProcessError(
+        result.returncode,
+        cmd,
+        output=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+def _pip_install_error(
+    packages: list[str], exc: subprocess.CalledProcessError
+) -> RuntimeError:
+    """Build a clearer error when pip cannot install into user_site."""
+    py_tag = f"{sys.version_info.major}.{sys.version_info.minor}"
+    detail = (exc.stderr or exc.output or "").strip()
+    if len(detail) > 2000:
+        detail = detail[-2000:]
+    hint = (
+        f"Failed to install {packages!r} into user_site for Python {py_tag}. "
+        "Prefer packages that publish binary wheels for this Python version; "
+        "source builds need a compiler (Docker images include build-essential). "
+        "Note: the PyPI package 'Github' pins aiohttp==3.8.1 and is incompatible "
+        "with Python 3.12+ — use 'PyGithub' for the GitHub API instead."
+    )
+    if detail:
+        return RuntimeError(f"{hint}\n\nPip output (tail):\n{detail}")
+    return RuntimeError(hint)
 
 
 def _ensure_pip_available() -> bool:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `build-essential`/`gcc`/`g++` to the Docker image so runtime `install_package()` can compile C-extension sdists when no wheel exists.
- Prefer binary wheels and wrap pip failures with a clearer error that points users at Python 3.12 wheel compatibility and the `Github` → `PyGithub` pitfall.
- Document the limitation in the README troubleshooting section.

## Why
`install_package("Github")` pulls `aiohttp==3.8.1` (no cp312 wheels). The slim image lacked `gcc`, so installs failed with `command 'gcc' failed`. Even with a compiler, that package remains incompatible with Python 3.12; users should use `PyGithub` instead. The Docker/compiler change still helps other packages that need source builds.

## Test plan
- [x] `install_package("PyGithub")` succeeds into an isolated `user_site`
- [x] `install_package("Github")` fails with the new RuntimeError guidance (not a bare missing-gcc message)
- [ ] Rebuild Docker image and confirm build tools are present
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9217e7fc-25ed-4932-80f9-9757f84d8be8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9217e7fc-25ed-4932-80f9-9757f84d8be8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

