### PR TITLE
Add beta Docker image builds for `dev` branch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,8 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - main  # Trigger only when main is updated (e.g., after a merge)
+      - main  # Stable image (:latest)
+      - dev   # Beta image (:beta)
 
 jobs:
   build:
@@ -33,14 +34,29 @@ jobs:
           REPO_LC="${GITHUB_REPOSITORY,,}"
           echo "repo=$REPO_LC" >> $GITHUB_OUTPUT
 
+      - name: Select image tags
+        id: tags
+        run: |
+          REPO="${{ steps.vars.outputs.repo }}"
+          SHA="${{ github.sha }}"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            CHANNEL_TAG="ghcr.io/${REPO}:latest"
+          else
+            CHANNEL_TAG="ghcr.io/${REPO}:beta"
+          fi
+          {
+            echo "tags<<EOF"
+            echo "${CHANNEL_TAG}"
+            echo "ghcr.io/${REPO}:${SHA}"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ghcr.io/${{ steps.vars.outputs.repo }}:latest
-            ghcr.io/${{ steps.vars.outputs.repo }}:${{ github.sha }}
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ DotCanvas 是一个轻量级的可视化Dot.编辑工具。
 
 ## Docker 部署
 
-我们已在 GitHub Container Registry 发布预构建镜像 `ghcr.io/lucasxingg/dotcanvas`，可以直接拉取并运行。
+我们已在 GitHub Container Registry 发布预构建镜像 `ghcr.io/lucasxingg/dotcanvas`，可以直接拉取并运行。`main` 分支推送发布 `:latest`，`dev` 分支推送发布 `:beta`。
 
 ```bash
-# 拉取镜像
+# 拉取稳定镜像
 docker pull ghcr.io/lucasxingg/dotcanvas:latest
+
+# 或拉取开发分支 beta 镜像
+# docker pull ghcr.io/lucasxingg/dotcanvas:beta
 
 # 运行容器（映射端口；建议同时挂载 configs 与 canvas，见下方「持久化」章节）
 docker run -d \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Every push to `dev` now builds and publishes a multi-arch beta image to GHCR, without overwriting the stable `:latest` tag from `main`.

## Changes

- **`.github/workflows/docker-publish.yml`**: Trigger on `dev` as well as `main`. Select tags by branch:
  - `main` → `:latest` + `:<sha>`
  - `dev` → `:beta` + `:<sha>`
- **`README.md`**: Document the `:beta` pull tag.

## Usage

```bash
docker pull ghcr.io/lucasxingg/dotcanvas:beta
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eed87215-fff2-40c6-9369-3a52a978994d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eed87215-fff2-40c6-9369-3a52a978994d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

